### PR TITLE
Inventory fix

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -566,21 +566,26 @@ namespace FlavoursOfFallout
 
         static void DisplayInventory(ref Player player, ref Enemy enemy)
         {
+            Console.Clear();
             Console.WriteLine("Inventory:");
-            Console.WriteLine("Slot | Item");
-            Console.WriteLine("---------------");
+            Console.WriteLine(" Slot │ Item");
             if (inventory.Count == 0)
             {
+                Console.WriteLine("──────┴────────");
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("Your inventory is empty!");
                 Console.ResetColor();
+                Console.WriteLine("Press enter to go back");
+                Console.ReadLine();
+                return;
             }
             else
             {
+                Console.WriteLine("──────┼────────");
                 for (int i = 0; i < inventory.Count; i++)
                 {
-                    string item = string.IsNullOrEmpty(inventory[i]) ? "[Empty]" : inventory[i];
-                    Console.WriteLine($"{i + 1,4} | {item}");
+                    string item = inventory[i];
+                    Console.WriteLine($"{i + 1,5} │ {item}");
                 }
             }
                 

--- a/Program.cs
+++ b/Program.cs
@@ -567,8 +567,16 @@ namespace FlavoursOfFallout
         static void DisplayInventory(ref Player player, ref Enemy enemy)
         {
             Console.Clear();
-            Console.WriteLine("Inventory:");
-            Console.WriteLine(" Slot │ Item");
+            Console.WriteLine("" +
+                " _____                     _                   \r\n" +
+                "|_   _|                   | |                  \r\n" +
+                "  | | _ ____   _____ _ __ | |_ ___  _ __ _   _ \r\n" +
+                "  | || '_ \\ \\ / / _ \\ '_ \\| __/ _ \\| '__| | | |\r\n" +
+                " _| || | | \\ V /  __/ | | | || (_) | |  | |_| |\r\n" +
+                " \\___/_| |_|\\_/ \\___|_| |_|\\__\\___/|_|   \\__, |\r\n" +
+                "                                          __/ |\r\n" +
+                "                                         |___/ ");
+            Console.WriteLine(" Slot │ Item ");
             if (inventory.Count == 0)
             {
                 Console.WriteLine("──────┴────────");

--- a/Program.cs
+++ b/Program.cs
@@ -75,7 +75,7 @@ namespace FlavoursOfFallout
         private static Random random = new Random();
         private static int Task;
         public static string charName, cookbook = "";
-        public static List<string> inventory = ["", "", "", "", "", "", "", "", "", ""]; 
+        public static List<string> inventory = new List<string>(); 
         public static List<string> foodSatchel = new List<string>();
 
         static void Welcome()
@@ -569,11 +569,21 @@ namespace FlavoursOfFallout
             Console.WriteLine("Inventory:");
             Console.WriteLine("Slot | Item");
             Console.WriteLine("---------------");
-            for (int i = 0; i < inventory.Count; i++)
+            if (inventory.Count == 0)
             {
-                string item = string.IsNullOrEmpty(inventory[i]) ? "[Empty]" : inventory[i];
-                Console.WriteLine($"{i + 1,4} | {item}");
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("Your inventory is empty!");
+                Console.ResetColor();
             }
+            else
+            {
+                for (int i = 0; i < inventory.Count; i++)
+                {
+                    string item = string.IsNullOrEmpty(inventory[i]) ? "[Empty]" : inventory[i];
+                    Console.WriteLine($"{i + 1,4} | {item}");
+                }
+            }
+                
             Console.WriteLine();
 
             Console.WriteLine("What would you like to do?");
@@ -601,7 +611,7 @@ namespace FlavoursOfFallout
                             int healAmount = Convert.ToInt32(itemDetails[2]);
                             player.playerHP = player.playerHP + healAmount;
                             Console.WriteLine($"You used {itemDetails[0]} and healed for {healAmount} HP!");
-                            inventory[itemSlot] = "";
+                            inventory.RemoveAt(itemSlot);
                             Console.ReadLine();
                         }
                         else if (itemDetails.Length >= 3 && itemDetails[1] == "Explosive")
@@ -610,7 +620,7 @@ namespace FlavoursOfFallout
                             enemy.enemyHP = enemy.enemyHP - damageAmount;
                             Console.WriteLine("***HUGE EXPLOSIONS***");
                             Console.WriteLine($"You used {itemDetails[0]} against {enemy.enemyName} dealing {damageAmount} damage!");
-                            inventory[itemSlot] = "";
+                            inventory.RemoveAt(itemSlot);
                             Console.ReadLine();
                         }
                     }
@@ -632,7 +642,7 @@ namespace FlavoursOfFallout
                             player.playerWeapon = weaponDetails[0];
                             player.playerAttack = Convert.ToInt32(weaponDetails[1]);
                             Console.WriteLine($"You equipped {player.playerWeapon} with {player.playerAttack} attack power!");
-                            inventory[weaponSlot] = "";
+                            inventory.RemoveAt(weaponSlot);
                             Console.ReadLine();
                         }
                         else
@@ -653,7 +663,7 @@ namespace FlavoursOfFallout
                     dropSlot = Convert.ToInt32(temp) - 1;
                     if (dropSlot >= 0 && dropSlot < inventory.Count && !string.IsNullOrEmpty(inventory[dropSlot]))
                     {
-                        inventory[dropSlot] = "";
+                        inventory.RemoveAt(dropSlot);
                     }
                     else
                     {

--- a/Program.cs
+++ b/Program.cs
@@ -343,13 +343,13 @@ namespace FlavoursOfFallout
                 "\nAll of a sudden a crow comes eye to eye with you, twitchingly eyeing you up.");
             Console.WriteLine("Press any key to continue...");
             Console.ReadLine();
-            Console.Beep(319, 100);
-            Console.Beep(319, 100);
-            Console.Beep(319, 100);
-            Console.Beep(319, 100);
-            Console.Beep(319, 100);
-            Console.Beep(319, 100);
-            Console.Beep(213, 100);
+            //Console.Beep(319, 100);
+            //Console.Beep(319, 100);
+            //Console.Beep(319, 100);
+            //Console.Beep(319, 100);
+            //Console.Beep(319, 100);
+            //Console.Beep(319, 100);
+            //Console.Beep(213, 100);
             Enemy enemy = Enemy.storyModeMonsters[14];
             CombatSystem(ref player, enemy); //Crow fight
             Console.Clear();


### PR DESCRIPTION
Changed the inventory display menu

The inventory no longer has empty slots. Now your inventory starts at no slots until you get any items. As you get more items, your inventory grows in size. When you consume, equip, or drop items, the slot will disappear. This makes it look much cleaner